### PR TITLE
Fix dubious ownership Git error in workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Configure Git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
Add git config step to mark workspace as safe directory before
running Claude Code. This resolves the ownership mismatch that
occurs when running inside the Unity CI Docker container.